### PR TITLE
Support multi-day holidays

### DIFF
--- a/src/lib/holidayUtils.ts
+++ b/src/lib/holidayUtils.ts
@@ -30,7 +30,11 @@ const formatDate = (date: Date): string => date.toLocaleDateString('en-US', { mo
 
 // Get holidays for a specific year and country
 export function getHolidaysForYear(countryCode: string, year: number, stateCode?: string): { date: Date; name: string }[] {
-    const hd = stateCode ? new Holidays(countryCode, stateCode) : new Holidays(countryCode);
+    // The date-holidays lib has translations for many holidays, but defaults to using the language of the country.
+    // We can pass in the browser's preferred languages (though the lib doesn't fall back, e.g. from `de-AT` to `de`)
+    const languages = navigator.languages.map(lang => lang.split('-')[0]);
+    const opts = { languages }
+    const hd = stateCode ? new Holidays(countryCode, stateCode, opts) : new Holidays(countryCode, opts);
     return hd.getHolidays(year)
         .filter(holiday => holiday.type === 'public')
         .map(holiday => ({


### PR DESCRIPTION
Thanks for a cool tool, and congrats on the HN fame! 😄

In case you're interested in accepting PRs…

I saw that the `date-holidays` library has info on whether a holiday spans multiple days, and so here I've taken that into account. For a span of N days, I just generate an array of N days, each with the same holiday name.
It seems to work as expected for a few countries I checked (Bahrain, Russia, Vietnam).

(I also learned that JS actually calculates the correct date, if you add an arbitrary number of days to boundaries like `new Date(2024, 12, 31 + i)` 😅 )

Since the library also has translations for many holidays, I made it possible to show their names in the browser's preferred language(s), rather than all holidays appearing in the language of the selected country.

**Before and after:**
<img width="1329" alt="Before and after screenshot" src="https://github.com/user-attachments/assets/fe24ea0b-0ff5-47e4-8be3-4c4359fcb614">
