### PR TITLE
use getWeekInfo() instead of weekInfo

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -267,7 +267,7 @@
         const normalizedLocale = locale.toLowerCase() === 'us' ? 'en-US' : `en-${locale.toUpperCase()}`;
         try {
             // @ts-ignore
-            const weekFirstDay = new Intl.Locale(normalizedLocale)?.weekInfo?.firstDay;
+            const weekFirstDay = new Intl.Locale(normalizedLocale)?.getWeekInfo()?.firstDay;
             if (weekFirstDay !== undefined) {
                 return weekFirstDay;
             }


### PR DESCRIPTION
weekInfo is changed to getWeekInfo() in https://tc39.es/proposal-intl-locale-info/

See tc39/proposal-intl-locale-info#67